### PR TITLE
Metadata without delimiters

### DIFF
--- a/full_yaml_metadata.py
+++ b/full_yaml_metadata.py
@@ -7,7 +7,12 @@ import yaml
 class FullYamlMetadataExtension(markdown.Extension):
     """Extension for parsing YAML metadata part with Python-Markdown."""
     def __init__(self, **kwargs):
-        self.config = {}
+        self.config = {
+            "yaml_loader": [
+                yaml.FullLoader,
+                "YAML loader to use. Default: yaml.FullLoader",
+            ],
+        }
         super().__init__(**kwargs)
 
     def extendMarkdown(self, md: markdown.Markdown, *args, **kwargs):
@@ -34,7 +39,8 @@ class FullYamlMetadataPreprocessor(markdown.preprocessors.Preprocessor):
     def run(self, lines: list) -> list:
         meta_lines, lines = self.split_by_meta_and_content(lines)
 
-        self.md.Meta = yaml.load("\n".join(meta_lines), Loader=yaml.FullLoader)
+        loader = self.config.get("yaml_loader", yaml.FullLoader)
+        self.md.Meta = yaml.load("\n".join(meta_lines), Loader=loader)
         return lines
 
     def split_by_meta_and_content(self, lines: list) -> typing.Tuple[list]:

--- a/full_yaml_metadata.py
+++ b/full_yaml_metadata.py
@@ -6,11 +6,17 @@ import yaml
 
 class FullYamlMetadataExtension(markdown.Extension):
     """Extension for parsing YAML metadata part with Python-Markdown."""
+    def __init__(self, **kwargs):
+        self.config = {}
+        super().__init__(**kwargs)
 
     def extendMarkdown(self, md: markdown.Markdown, *args, **kwargs):
+        md.registerExtension(self)
         md.Meta = None
         md.preprocessors.register(
-            FullYamlMetadataPreprocessor(md), "full_yaml_metadata", 1
+            FullYamlMetadataPreprocessor(md, self.getConfigs()),
+            "full_yaml_metadata",
+            1,
         )
 
 
@@ -20,6 +26,10 @@ class FullYamlMetadataPreprocessor(markdown.preprocessors.Preprocessor):
     YAML block is delimited by '---' at start and '...' or '---' at end.
 
     """
+
+    def __init__(self, md, config):
+        super().__init__(md)
+        self.config = config
 
     def run(self, lines: list) -> list:
         meta_lines, lines = self.split_by_meta_and_content(lines)

--- a/full_yaml_metadata.py
+++ b/full_yaml_metadata.py
@@ -12,6 +12,11 @@ class FullYamlMetadataExtension(markdown.Extension):
                 yaml.FullLoader,
                 "YAML loader to use. Default: yaml.FullLoader",
             ],
+            "allow_missing_delimiters": [
+                False,
+                "Attempt to split by blank line if metadata delimiters were "
+                "not found. Default: False",
+            ],
         }
         super().__init__(**kwargs)
 
@@ -37,27 +42,58 @@ class FullYamlMetadataPreprocessor(markdown.preprocessors.Preprocessor):
         self.config = config
 
     def run(self, lines: list) -> list:
-        meta_lines, lines = self.split_by_meta_and_content(lines)
+        metadata, content_lines = self.parse_meta_delimited(lines)
+        if metadata is None and self.config.get("allow_missing_delimiters"):
+            metadata, content_lines = self.parse_meta_fuzzy(lines)
+        self.md.Meta = metadata
 
+        return content_lines
+
+    def parse_meta_block(self, meta):
         loader = self.config.get("yaml_loader", yaml.FullLoader)
-        self.md.Meta = yaml.load("\n".join(meta_lines), Loader=loader)
-        return lines
+        return yaml.load(meta, Loader=loader)
 
-    def split_by_meta_and_content(self, lines: list) -> typing.Tuple[list]:
+    def parse_meta_delimited(self, lines: list) -> typing.Tuple[dict, list]:
+        """
+        Find and parse YAML data in text by looking for delimiters.
+        """
         meta_lines = []
         if lines[0] != "---":
-            return meta_lines, lines
+            # YAML metadata delimiters not found
+            return None, lines
 
-        lines.pop(0)
-        for line in lines:  # type: str
+        content_lines = []
+        for i, line in enumerate(lines[1:], start=1):  # type: str
             if line in ("---", "..."):
-                content_starts_at = lines.index(line) + 1
-                lines = lines[content_starts_at:]
+                content_starts_at = i + 1
+                content_lines = lines[content_starts_at:]
                 break
 
             meta_lines.append(line)
 
-        return meta_lines, lines
+        metadata = self.parse_meta_block("\n".join(meta_lines))
+        return metadata, content_lines
+
+    def parse_meta_fuzzy(self, lines: list) -> typing.Tuple[dict, list]:
+        """
+        Find and parse YAML data in text by splitting by the first blank line.
+        """
+
+        content_starts_at = lines.index('') + 1
+        meta_lines = lines[:content_starts_at]
+        content_lines = lines[content_starts_at:]
+
+        try:
+            metadata = self.parse_meta_block("\n".join(meta_lines))
+        except yaml.error.YAMLError:
+            return None, lines
+
+        # Prevent false-positives if the text does not begin with a
+        # metadata block
+        if isinstance(metadata, str):
+            return None, lines
+
+        return metadata, content_lines
 
 
 def makeExtension(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 
 from setuptools import setup


### PR DESCRIPTION
Follow up to #20 because this also adds config options. Fixes: https://github.com/sivakov512/python-markdown-full-yaml-metadata/issues/19.