### PR TITLE
Support space after metadata delimitation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/full_yaml_metadata.py
+++ b/full_yaml_metadata.py
@@ -49,12 +49,12 @@ class FullYamlMetadataPreprocessor(Preprocessor):
         self, lines: List[str]
     ) -> Tuple[List[str], List[str]]:
         meta_lines: List[str] = []
-        if lines[0] != "---":
+        if lines[0].rstrip(" ") != "---":
             return meta_lines, lines
 
         lines.pop(0)
         for line in lines:  # type: str
-            if line in ("---", "..."):
+            if line.rstrip(" ") in ("---", "..."):
                 content_starts_at = lines.index(line) + 1
                 lines = lines[content_starts_at:]
                 break

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flake8-quotes==3.2.0
 iniconfig==1.1.1
 isort==5.9.2
 jedi==0.17.2
-Markdown==3.3.4
+Markdown==3.4.1
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,14 @@ setup(
     long_description_content_type="text/markdown",
     name="markdown-full-yaml-metadata",
     py_modules=["full_yaml_metadata"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     version="2.1.1",
     url="https://github.com/sivakov512/python-markdown-full-yaml-metadata",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name="markdown-full-yaml-metadata",
     py_modules=["full_yaml_metadata"],
     python_requires=">=3.6",
-    version="2.1.0",
+    version="2.1.1",
     url="https://github.com/sivakov512/python-markdown-full-yaml-metadata",
     classifiers=[
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Nikita Sivakov",
     author_email="sivakov512@gmail.com",
     description="YAML metadata extension for Python-Markdown",
-    install_requires=["Markdown~=3.0", "PyYAML~=5.0"],
+    install_requires=["Markdown~=3.4", "PyYAML~=5.0"],
     keywords="markdown yaml meta metadata",
     license="MIT",
     long_description=read("README.md"),

--- a/tests/test_metadata_parsing.py
+++ b/tests/test_metadata_parsing.py
@@ -147,6 +147,36 @@ def test_without_metadata(source, expected_body):
     assert md.Meta is None
 
 
+@pytest.mark.parametrize(
+    "source, expected_meta, expected_body",
+    (
+        [
+            "---\n"
+            "title: What is Lorem Ipsum?\n"
+            "---        \n"
+            "Lorem Ipsum is simply dummy text.\n",
+            {"title": "What is Lorem Ipsum?"},
+            "<p>Lorem Ipsum is simply dummy text.</p>",
+        ],
+        [
+            "---     \n"
+            "title: What is Lorem Ipsum?\n"
+            "---\n"
+            "Lorem Ipsum is simply dummy text.\n",
+            {"title": "What is Lorem Ipsum?"},
+            "<p>Lorem Ipsum is simply dummy text.</p>",
+        ],
+    ),
+)
+def test_should_support_space_after_metadata_delimiter(
+    source, expected_meta, expected_body
+):
+    md = markdown.Markdown(extensions=["full_yaml_metadata"])
+
+    assert md.convert(source) == expected_body
+    assert md.Meta == expected_meta
+
+
 def test_meta_is_acceccable_before_parsing():
     md = markdown.Markdown(extensions=["full_yaml_metadata"])
 


### PR DESCRIPTION
Hello !
I propose to add the support of spaces after metadata delimiting. Currently if a markdown file contains metadata and a space after the metadata delimiter, the markdown parser crashes.
Example : 
```
---
title: What is Lorem Ipsum?
---        
Lorem Ipsum is simply dummy text.
```

There are spaces after the end of metadata declaration (the third line is equal to '---        ').
If we try to parse the example above with the 'full_yaml_metadata' plugin we get the following error :
```
E           yaml.composer.ComposerError: expected a single document in the stream
E             in "<unicode string>", line 1, column 1:
E               title: What is Lorem Ipsum?
E               ^
E           but found another document
E             in "<unicode string>", line 2, column 1:
E               ---        
E               ^
```
So I propose this little correction, hoping that you will accept it. If you have any remark on the code or on the test don't hesitate to sharing them with me, I would be glad to correct it.